### PR TITLE
style: make review summary gauge card responsive

### DIFF
--- a/client/src/modules/Course/Components/Gauges.tsx
+++ b/client/src/modules/Course/Components/Gauges.tsx
@@ -157,12 +157,14 @@ const Gauges = ({overall, difficulty, workload}: GaugesProps) => {
                                     />
                         })}
                     </div>
-                    <div className={styles.ratingNum}> {difficulty ? difficulty.toPrecision(2) : "-"} </div>
-                    <img src={difficultyEmote}
-                         className={styles.emote}
-                         title={difficultyHover}
-                         alt={difficultyHover}
-                    />
+                    <div className={styles.responsiveLabel}>
+                        <div className={styles.ratingNum}> {difficulty ? difficulty.toPrecision(2) : "-"} </div>
+                        <img src={difficultyEmote}
+                            className={styles.emote}
+                            title={difficultyHover}
+                            alt={difficultyHover}
+                        />
+                    </div>
                 </div>
                 <div className={styles.horizontal}>
                     <div className={styles.category}> Workload </div>
@@ -174,12 +176,14 @@ const Gauges = ({overall, difficulty, workload}: GaugesProps) => {
                                     />
                         })}
                     </div>
-                    <div className={styles.ratingNum}> {workload ? workload.toPrecision(2) : "-"} </div>
-                    <img src={workloadEmote}
-                         className={styles.emote}
-                         title={workloadHover}
-                         alt={workloadHover}
-                    />
+                    <div className={styles.responsiveLabel}>
+                        <div className={styles.ratingNum}> {workload ? workload.toPrecision(2) : "-"} </div>
+                        <img src={workloadEmote}
+                            className={styles.emote}
+                            title={workloadHover}
+                            alt={workloadHover}
+                        />
+                    </div>
                 </div>
             </div>
         </div>

--- a/client/src/modules/Course/Styles/Gauges.module.css
+++ b/client/src/modules/Course/Styles/Gauges.module.css
@@ -92,9 +92,15 @@
     font-weight: 590;
 }
 
-@media only screen and (max-width: 1216px) {
+.responsiveLabel {
+    display: flex;
+    flex-direction: row;
+    gap: 14px;
+}
+
+@media only screen and (max-width: 1124px) {
     .container {
-        gap: 24px;
+        gap: 12px;
         flex-direction: column;
     }
 
@@ -139,6 +145,7 @@
 
     .ratings {
         height: auto;
+        gap: 12px;
     }
 
     .bars {
@@ -151,5 +158,11 @@
 
     .bar {
         width: 30px;
+    }
+
+    .responsiveLabel {
+        display: flex;
+        flex-flow: row nowrap;
+        gap: 10px;
     }
 }

--- a/client/src/modules/Course/Styles/Gauges.module.css
+++ b/client/src/modules/Course/Styles/Gauges.module.css
@@ -95,6 +95,7 @@
 @media only screen and (max-width: 1216px) {
     .container {
         gap: 24px;
+        flex-direction: column;
     }
 
     .overallScore {
@@ -128,11 +129,16 @@
 
     .horizontal {
         gap: 6px;
+        flex-direction: column;
     }
 
     .ratingNum {
         font-size: 14px;
         font-weight: 590;
+    }
+
+    .ratings {
+        height: auto;
     }
 
     .bars {


### PR DESCRIPTION
# Summary

Helps mobile & tablet users of CUReviews go from 😠 to 👌 when looking at the ratings page for a course! Thanks to this PR, the summary card at the top of said ratings page is now responsive.

## PR Type

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile + Desktop Screenshots & Recordings

https://github.com/user-attachments/assets/5dfb223f-0913-4677-ac22-d53ea8a268f7

## QA - Test Plan

Drag around the window size & confirm that the summary / review info card is responsive / fully visible under `1216px` (compare with [the live version](https://cureviews.org) of CUReviews).

## Breaking Changes & Notes

Zip

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 notion
- [ ] 🍕 ...
- [ ] 📕 ...
- [x] 🙅 no documentation needed

## What GIF represents this PR?

[gif](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExN3FkMnh5OTZnZ3k2YndjYzNhNnJ2NXhsMjI1bXlkb2hob3oxYm9vYiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/PmABbbUe3IqUKSOIBV/giphy.webp)
