### PR TITLE
Removed max width of navbar

### DIFF
--- a/client/src/modules/Globals/Styles/NavBar.module.css
+++ b/client/src/modules/Globals/Styles/NavBar.module.css
@@ -10,7 +10,6 @@
 
 .navbar {
   width: 100%;
-  max-width: 1440px;
 
   display: flex;
   flex-flow: row nowrap;


### PR DESCRIPTION
# Summary

This PR expands the navbar to full length. (Early contender for smallest PR of the semester?)

## PR Type

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile + Desktop Screenshots & Recordings
https://github.com/user-attachments/assets/03ef45ce-ef1e-4612-80ef-2c3f884e2aa3

## QA - Test Plan
Tested on a variety of dimensions and zoom factors.

## Breaking Changes & Notes
This felt like too simple of a fix, but I can't figure out why the max-width was there in the first place -- any additional insight would be helpful!

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 notion
- [ ] 🍕 ...
- [ ] 📕 ...
- [x] 🙅 no documentation needed

## What GIF represents this PR?

[gif](https://www.icegif.com/wp-content/uploads/tom-and-jerry-icegif-4.gif)
