### PR TITLE
Fixed search bar order

### DIFF
--- a/client/src/modules/SearchBar/Components/SearchBar.tsx
+++ b/client/src/modules/SearchBar/Components/SearchBar.tsx
@@ -263,8 +263,8 @@ export const SearchBar = ({
       return (
         <div>
           <ExactSearch />
-          <ProfessorsList />
           <SubjectsList />
+          <ProfessorsList />
           <CourseList />
         </div>
       );


### PR DESCRIPTION
# Summary

This PR works on the search bar feature.

## PR Type

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix

## Breaking Changes & Notes
Previously, due to an error in the order search results appear (profs -> subj -> classes), when you tab down with the down arrow, it would bounce around from subject back up to profs. You can test this on your own in the site by querying a major and see how it looks funny! Heres the issue page where Megan noticed: [https://www.notion.so/Backlog-List-11a0ad723ce180c7a2d0ef54951c96b7?p=1cf0ad723ce180aa9f99cafa945e49e3&pm=s](url)

Fixed this

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 notion
- [ ] 🍕 ...
- [ ] 📕 ...
- [ ] 🙅 no documentation needed

## What GIF represents this PR?

[gif](https://www.icegif.com/wp-content/uploads/tom-and-jerry-icegif-4.gif)
